### PR TITLE
Feat/add release workflows

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -9,6 +9,10 @@ on:
     secrets:
       GIT_HUB_PAT:
         required: true
+    outputs:
+      version:
+        description: "The first job output"
+        value: ${{ jobs.get_version.outputs.version }}
 
 
 jobs:
@@ -27,19 +31,22 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: utilant/ci_runner
-          ref: 2.1.0a0
+          ref: feat/adding_versioning_logic
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Get version number
         id: version-number
         run: |
-          pip install packaging
-          python .github/scripts/versioning.py $(if ${{ inputs.release }}; then echo "--release"; fi)
+          pip install packaging requests
+          python .github/scripts/versioning.py --repo ${GITHUB_REPOSITORY#*/} --token ${{ secrets.GITHUB_TOKEN }} --branch ${GITHUB_REF#refs/heads/} $(if ${{ inputs.release }}; then echo "--release"; fi)
   create_release:
     name: Create Release
     needs: [get_version]
     runs-on: self-hosted
     steps:
+      - name: Get branch name
+        id: branch-name
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Create Release
@@ -48,7 +55,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.configure.outputs.version }}
-          release_name: ${{ needs.configure.outputs.version }}
+          tag_name: ${{ needs.get_version.outputs.version }}
+          release_name: ${{ needs.get_version.outputs.version }}
           draft: false
           prerelease: ${{ !inputs.release }}
+          commitish: ${{ steps.branch-name.outputs.branch }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       version: ${{ steps.version-number.outputs.version }}
     container:
-      image: docker://python:3.8-slim-buster
+      image: docker://python:3.8
       options: --user 1001:1001
     name: Get version
     steps:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,55 @@
+name: Create Release
+
+on: 
+  workflow_call:
+    inputs:
+      release:
+        required: true
+        type: boolean
+    secrets:
+      GIT_HUB_PAT:
+        required: true
+
+
+jobs:
+  get_version:
+    runs-on: self-hosted
+    outputs:
+      version: ${{ steps.version-number.outputs.version }}
+    container:
+      image: docker://python:3.8-slim-buster
+      options: --user 1001:1001
+    name: Get version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: utilant/ci_runner
+          ref: 2.1.0a0
+          token: ${{ secrets.GIT_HUB_PAT }}
+          path: .github
+      - name: Get version number
+        if: ${{ inputs.release }}
+        run: python .github/scripts/versioning.py --release
+      - name: Get version number
+        id: version-number
+        run: python .github/scripts/versioning.py $(if [ ${{ inputs.release }} ]; then echo "--release"; fi)
+  create_release:
+    name: Create Release
+    needs: [get_version]
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.configure.outputs.version }}
+          release_name: ${{ needs.configure.outputs.version }}
+          draft: false
+          prerelease: ${{ !inputs.release }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -31,11 +31,10 @@ jobs:
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Get version number
-        if: ${{ inputs.release }}
-        run: python .github/scripts/versioning.py --release
-      - name: Get version number
         id: version-number
-        run: python .github/scripts/versioning.py $(if [ ${{ inputs.release }} ]; then echo "--release"; fi)
+        run: |
+        pip install packaging
+        python .github/scripts/versioning.py $(if ${{ inputs.release }}; then echo "--release"; fi)
   create_release:
     name: Create Release
     needs: [get_version]

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       version: ${{ steps.version-number.outputs.version }}
     container:
-      image: docker://python:3.8
+      image: docker://python:3.8-slim-buster
       options: --user 1001:1001
     name: Get version
     steps:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Get version number
         id: version-number
         run: |
-        pip install packaging
-        python .github/scripts/versioning.py $(if ${{ inputs.release }}; then echo "--release"; fi)
+          pip install packaging
+          python .github/scripts/versioning.py $(if ${{ inputs.release }}; then echo "--release"; fi)
   create_release:
     name: Create Release
     needs: [get_version]

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -33,4 +33,4 @@ jobs:
         if: ${{ inputs.version != '' }}
         run: |
           python3 .github/scripts/update_version.py --version ${{ inputs.version }}
-          python3 .github/scripts/docker_push.py ${{ inputs.image }} --release ${{ inputs.version }}
+          python3 .github/scripts/docker_push.py ${{ inputs.image }} --version ${{ inputs.version }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Docker build and push
-        if: ${{ !inputs.version = '' }}
+        if: ${{ inputs.version == '' }}
         run: python3 .github/scripts/docker_push.py ${{ inputs.image }}
       - name: Docker build and push
         if: ${{ inputs.version != '' }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: utilant/ci_runner
-          ref: feat/adding_versioning_logic
+          ref: 2.x
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Docker build and push

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -27,10 +27,10 @@ jobs:
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Docker build and push
-        if: ${{ !inputs.version = "" }}
+        if: ${{ !inputs.version = '' }}
         run: python3 .github/scripts/docker_push.py ${{ inputs.image }}
       - name: Docker build and push
-        if: ${{ inputs.version != "" }}
+        if: ${{ inputs.version != '' }}
         run: |
           python3 .github/scripts/update_version.py --version ${{ inputs.version }}
           python3 .github/scripts/docker_push.py ${{ inputs.image }} --release ${{ inputs.version }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -6,9 +6,9 @@ on:
       image:
         required: true
         type: string
-      release:
-        required: true
-        type: boolean
+      version:
+        required: false
+        type: string
     secrets:
       GIT_HUB_PAT:
         required: true
@@ -23,12 +23,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: utilant/ci_runner
-          ref: 2.x
+          ref: feat/adding_versioning_logic
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Docker build and push
-        if: ${{ !inputs.release }}
+        if: ${{ !inputs.version = "" }}
         run: python3 .github/scripts/docker_push.py ${{ inputs.image }}
       - name: Docker build and push
-        if: ${{ inputs.release }}
-        run: python3 .github/scripts/docker_push.py ${{ inputs.image }} --release
+        if: ${{ inputs.version != "" }}
+        run: |
+          python3 .github/scripts/update_version.py --version ${{ inputs.version }}
+          python3 .github/scripts/docker_push.py ${{ inputs.image }} --release ${{ inputs.version }}

--- a/.github/workflows/pip_release.yml
+++ b/.github/workflows/pip_release.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Replace package version
-        if: ${{ inputs.version != "" }}
+        if: ${{ inputs.version != '' }}
         run: python3 .github/scripts/update_version.py --version ${{ inputs.version }}
       - name: Release python package
         run: ./.github/scripts/release_package.sh

--- a/.github/workflows/pip_release.yml
+++ b/.github/workflows/pip_release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: utilant/ci_runner
-          ref: feat/adding_versioning_logic
+          ref: 2.x
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Replace package version

--- a/.github/workflows/pip_release.yml
+++ b/.github/workflows/pip_release.yml
@@ -2,6 +2,10 @@ name: Python package release
 
 on: 
   workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
     secrets:
       GIT_HUB_PAT:
         required: true
@@ -19,8 +23,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: utilant/ci_runner
-          ref: 2.x
+          ref: feat/adding_versioning_logic
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
+      - name: Replace package version
+        if: ${{ inputs.version != "" }}
+        run: python3 .github/scripts/update_version.py --version ${{ inputs.version }}
       - name: Release python package
         run: ./.github/scripts/release_package.sh


### PR DESCRIPTION
This PR adds the workflows used to automatically bump the version of a repo upon a push.

An example of these workflows in action here: https://github.com/utilant/ci-test-service/blob/testing-gh-actions/.github/workflows/on_push.yml
Corresponding job here: https://github.com/utilant/ci-test-service/actions/runs/2184254599

*Note: upon release of updates to `ci_runner` repo (deletion of branch `feat/adding_versioning_logic`), the `ref`s in these files should be reverted to `2.x`.*