### PR TITLE
fixing minor versioning issues

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: utilant/ci_runner
-          ref: feat/adding_versioning_logic
+          ref: 2.x
           token: ${{ secrets.GIT_HUB_PAT }}
           path: .github
       - name: Get version number

--- a/example_workflows/on_dockerfile_push.yml
+++ b/example_workflows/on_dockerfile_push.yml
@@ -10,6 +10,5 @@ jobs:
     uses: utilant/ci_workflows/.github/workflows/docker_build.yml@0.x
     with:
       image: my-docker-image
-      release: false
     secrets:
       GIT_HUB_PAT: ${{ secrets.GIT_HUB_PAT }}

--- a/example_workflows/release.yml
+++ b/example_workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     uses: utilant/ci_workflows/.github/workflows/docker_build.yml@0.x
     with:
       image: my-docker-image
-      release: true
+      version: ${{ github.event.release.tag_name }}
     secrets:
       GIT_HUB_PAT: ${{ secrets.GIT_HUB_PAT }}
   on-push:


### PR DESCRIPTION
This PR addresses a handful of minor issues introduced by the previous PR. Namely, it:
1. Changes a reference in the `create_release` workflow from a stale branch to the most recent release, and
2. Updates the example workflows to conform to the new inputs expected by the `docker_build` workflow.

These changes have been tested on [this repo / branch](https://github.com/utilant/subrogation_detector/tree/initial_attempt), PR forthcoming.

*Note to self: after merging PR, remember to cut new release of workflows.*